### PR TITLE
Add PHP 8.2 support with static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,13 @@
     "license": "MIT",
     "type": "project",
     "require": {
+        "php": "^8.2",
         "symfony/console": "^7.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^11.5"
+        "phpunit/phpunit": "^11.5",
+        "phpstan/phpstan": "^2.1",
+        "laravel/pint": "^1.24"
     },
     "autoload": {
         "psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7b407b3383106c30a79d301240014f42",
+    "content-hash": "7185e89fb66ebb4c12cf5dd03ec38bb4",
     "packages": [
         {
             "name": "psr/container",
@@ -712,6 +712,75 @@
     ],
     "packages-dev": [
         {
+            "name": "laravel/pint",
+            "version": "v1.24.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/pint.git",
+                "reference": "0345f3b05f136801af8c339f9d16ef29e6b4df8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/0345f3b05f136801af8c339f9d16ef29e6b4df8a",
+                "reference": "0345f3b05f136801af8c339f9d16ef29e6b4df8a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-tokenizer": "*",
+                "ext-xml": "*",
+                "php": "^8.2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.82.2",
+                "illuminate/view": "^11.45.1",
+                "larastan/larastan": "^3.5.0",
+                "laravel-zero/framework": "^11.45.0",
+                "mockery/mockery": "^1.6.12",
+                "nunomaduro/termwind": "^2.3.1",
+                "pestphp/pest": "^2.36.0"
+            },
+            "bin": [
+                "builds/pint"
+            ],
+            "type": "project",
+            "autoload": {
+                "files": [
+                    "overrides/Runner/Parallel/ProcessFactory.php"
+                ],
+                "psr-4": {
+                    "App\\": "app/",
+                    "Database\\Seeders\\": "database/seeders/",
+                    "Database\\Factories\\": "database/factories/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "An opinionated code formatter for PHP.",
+            "homepage": "https://laravel.com",
+            "keywords": [
+                "format",
+                "formatter",
+                "lint",
+                "linter",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/pint/issues",
+                "source": "https://github.com/laravel/pint"
+            },
+            "time": "2025-07-10T18:09:32+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.13.3",
             "source": {
@@ -946,6 +1015,64 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "2.1.18",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "ee1f390b7a70cdf74a2b737e554f68afea885db7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ee1f390b7a70cdf74a2b737e554f68afea885db7",
+                "reference": "ee1f390b7a70cdf74a2b737e554f68afea885db7",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-07-17T17:22:31+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2437,7 +2564,9 @@
     "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": "^8.2"
+    },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/src/Command.php
+++ b/src/Command.php
@@ -4,49 +4,41 @@ namespace Artisanize;
 
 use Artisanize\Input\Input;
 use Artisanize\Output\SymfonyOutput;
-use Symfony\Component\Console\Question\Question;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
-use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Question\Question;
 
 abstract class Command extends SymfonyCommand
 {
     /**
      * Symfony console output.
-     *
-     * @var SymfonyOutput
      */
-    protected $output;
+    protected ?SymfonyOutput $output = null;
 
     /**
      * Symfony input implementation.
-     *
-     * @var InputInterface
      */
-    protected $input;
+    protected InputInterface $input;
 
     /**
      * The command description.
-     *
-     * @var string
      */
-    protected $description;
+    protected string $description;
 
     /**
      * Command signature.
-     *
-     * @var null|string
      */
-    protected $signature = null;
+    protected ?string $signature = null;
 
     /**
      * Configure the command if signature is set.
      */
     protected function configure()
     {
-        if (!is_null($this->signature)) {
+        if (! is_null($this->signature)) {
             $parser = new SignatureParser($this);
 
             $parser->parse($this->signature);
@@ -57,11 +49,8 @@ abstract class Command extends SymfonyCommand
 
     /**
      * Execute the command.
-     *
-     * @param InputInterface  $input
-     * @param OutputInterface $output
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->output = new SymfonyOutput($output);
 
@@ -70,6 +59,8 @@ abstract class Command extends SymfonyCommand
         if (method_exists($this, 'handle')) {
             $this->handle();
         }
+
+        return SymfonyCommand::SUCCESS;
     }
 
     /**
@@ -95,8 +86,7 @@ abstract class Command extends SymfonyCommand
     /**
      * Get the value of a command argument.
      *
-     * @param string $key
-     *
+     * @param  string  $key
      * @return string|array
      */
     protected function argument($key = null)
@@ -111,8 +101,7 @@ abstract class Command extends SymfonyCommand
     /**
      * Determine if the given argument is present.
      *
-     * @param string|int $name
-     *
+     * @param  string|int  $name
      * @return bool
      */
     protected function hasArgument($name)
@@ -123,8 +112,7 @@ abstract class Command extends SymfonyCommand
     /**
      * Get the value of a command option.
      *
-     * @param string $key
-     *
+     * @param  string  $key
      * @return string|array
      */
     protected function option($key = null)
@@ -139,8 +127,7 @@ abstract class Command extends SymfonyCommand
     /**
      * Determine if the given option is present.
      *
-     * @param string $name
-     *
+     * @param  string  $name
      * @return bool
      */
     protected function hasOption($name)
@@ -150,8 +137,6 @@ abstract class Command extends SymfonyCommand
 
     /**
      * Add input to the command.
-     *
-     * @param Input $input
      */
     public function addInput(Input $input)
     {
@@ -167,8 +152,7 @@ abstract class Command extends SymfonyCommand
     /**
      * Ask for confirmation.
      *
-     * @param string $text
-     *
+     * @param  string  $text
      * @return mixed
      */
     public function confirm($text)
@@ -183,9 +167,8 @@ abstract class Command extends SymfonyCommand
     /**
      * Ask a question.
      *
-     * @param string     $question
-     * @param mixed|null $default
-     *
+     * @param  string  $question
+     * @param  mixed|null  $default
      * @return mixed
      */
     public function ask($question, $default = null)
@@ -200,8 +183,7 @@ abstract class Command extends SymfonyCommand
     /**
      * Ask a password.
      *
-     * @param string $question
-     *
+     * @param  string  $question
      * @return mixed
      */
     public function askPassword($question)
@@ -220,10 +202,8 @@ abstract class Command extends SymfonyCommand
     /**
      * Ask a question where the answer is available from a list of predefined choices.
      *
-     * @param string     $question
-     * @param array      $choices
-     * @param mixed|null $default
-     *
+     * @param  string  $question
+     * @param  mixed|null  $default
      * @return mixed
      */
     public function choose($question, array $choices, $default = null)
@@ -240,10 +220,8 @@ abstract class Command extends SymfonyCommand
     /**
      * Ask a question where some auto-completion help is provided.
      *
-     * @param string     $question
-     * @param array      $autoCompletion
-     * @param mixed|null $default
-     *
+     * @param  string  $question
+     * @param  mixed|null  $default
      * @return mixed
      */
     public function anticipate($question, array $autoCompletion, $default = null)
@@ -260,10 +238,8 @@ abstract class Command extends SymfonyCommand
     /**
      * Ask a question where the answer is available from a list of predefined choices and more choices can be selected.
      *
-     * @param string     $question
-     * @param array      $choices
-     * @param mixed|null $default
-     *
+     * @param  string  $question
+     * @param  mixed|null  $default
      * @return mixed
      */
     public function choice($question, array $choices, $default = null)

--- a/src/Input/Argument.php
+++ b/src/Input/Argument.php
@@ -8,17 +8,15 @@ class Argument extends Input
 {
     /**
      * Default arguement value.
-     *
-     * @var null|string
      */
-    protected $default = null;
+    protected ?string $default = null;
 
     /**
      * Parse the set argument string.
      *
      * @return $this
      */
-    public function parse()
+    public function parse(): static
     {
         return $this->setDescription()
             ->setArray('IS_ARRAY')
@@ -34,7 +32,7 @@ class Argument extends Input
      *
      * @return $this
      */
-    protected function setOptional()
+    protected function setOptional(): static
     {
         if (substr($this->input, -1) === '?') {
             $this->modeArray[] = 'OPTIONAL';
@@ -50,10 +48,10 @@ class Argument extends Input
      *
      * @return $this
      */
-    protected function setDefault()
+    protected function setDefault(): static
     {
         if (strpos($this->input, '=')) {
-            list($this->input, $this->default) = explode('=', $this->input);
+            [$this->input, $this->default] = explode('=', $this->input);
 
             $this->modeArray[] = 'OPTIONAL';
         }
@@ -66,9 +64,9 @@ class Argument extends Input
      *
      * @return $this
      */
-    protected function setRequired()
+    protected function setRequired(): static
     {
-        if (!in_array('OPTIONAL', $this->modeArray)) {
+        if (! in_array('OPTIONAL', $this->modeArray)) {
             $this->modeArray[] = 'REQUIRED';
         }
 
@@ -77,16 +75,14 @@ class Argument extends Input
 
     /**
      * Get the argument attributes.
-     *
-     * @return array
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return [
-            'name'        => $this->name,
-            'mode'        => $this->mode,
+            'name' => $this->name,
+            'mode' => $this->mode,
             'description' => $this->description,
-            'default'     => $this->default,
+            'default' => $this->default,
         ];
     }
 }

--- a/src/Input/Input.php
+++ b/src/Input/Input.php
@@ -6,50 +6,38 @@ abstract class Input
 {
     /**
      * Input.
-     *
-     * @var string
      */
-    protected $input;
+    protected string $input;
 
     /**
      * Original input string.
-     *
-     * @var string
      */
-    protected $original;
+    protected string $original;
 
     /**
      * Input name.
-     *
-     * @var string
      */
-    protected $name;
+    protected string $name;
 
     /**
      * Input description.
-     *
-     * @var null|string
      */
-    protected $description;
+    protected ?string $description = null;
 
     /**
      * Array of input modes to apply.
-     *
-     * @var array
      */
-    protected $modeArray = [];
+    protected array $modeArray = [];
 
     /**
      * Argument mode.
-     *
-     * @var int
      */
-    protected $mode = 0;
+    protected int $mode = 0;
 
     /**
      * Construct.
      *
-     * @param string $input
+     * @param  string  $input
      */
     public function __construct($input)
     {
@@ -62,23 +50,20 @@ abstract class Input
      *
      * @return $this
      */
-    abstract public function parse();
+    abstract public function parse(): static;
 
     /**
      * Get the input attributes.
-     *
-     * @return array
      */
-    abstract public function getAttributes();
+    abstract public function getAttributes(): array;
 
     /**
      * Set array modeArray value if value contains *.
      *
-     * @param string $constant
      *
      * @return $this
      */
-    protected function setArray($constant)
+    protected function setArray(string $constant): static
     {
         if (strpos($this->input, '*') !== false) {
             $this->modeArray[] = $constant;
@@ -94,7 +79,7 @@ abstract class Input
      *
      * @return $this
      */
-    protected function setDescription()
+    protected function setDescription(): static
     {
         if (strpos($this->input, ':') !== false) {
             $inputArray = array_map('trim', explode(':', $this->input));
@@ -110,11 +95,10 @@ abstract class Input
     /**
      * Calculate the mode score.
      *
-     * @param string $class
      *
      * @return $this
      */
-    protected function calculateMode($class)
+    protected function calculateMode(string $class): static
     {
         foreach ($this->modeArray as $constant) {
             $this->mode = $this->mode | constant($class.'::'.$constant);
@@ -128,7 +112,7 @@ abstract class Input
      *
      * @return $this
      */
-    protected function setName()
+    protected function setName(): static
     {
         $this->name = $this->input;
 

--- a/src/Input/Option.php
+++ b/src/Input/Option.php
@@ -8,24 +8,20 @@ class Option extends Input
 {
     /**
      * Option shortcut.
-     *
-     * @var null|string
      */
-    protected $shortcut = null;
+    protected ?string $shortcut = null;
 
     /**
      * Default option value.
-     *
-     * @var null|string
      */
-    protected $default = null;
+    protected ?string $default = null;
 
     /**
      * Parse the set input string.
      *
      * @return $this
      */
-    public function parse()
+    public function parse(): static
     {
         return $this->setDescription()
             ->setArray('VALUE_IS_ARRAY')
@@ -41,7 +37,7 @@ class Option extends Input
      *
      * @return $this
      */
-    protected function setValue()
+    protected function setValue(): static
     {
         if (strpos($this->input, '=') !== false) {
             if (substr($this->input, -1) === '=') {
@@ -49,7 +45,7 @@ class Option extends Input
 
                 $this->modeArray[] = 'VALUE_REQUIRED';
             } else {
-                list($this->input, $this->default) = explode('=', $this->input);
+                [$this->input, $this->default] = explode('=', $this->input);
 
                 $this->modeArray[] = 'VALUE_OPTIONAL';
             }
@@ -63,7 +59,7 @@ class Option extends Input
      *
      * @return $this
      */
-    protected function setEmptyMode()
+    protected function setEmptyMode(): static
     {
         $this->modeArray = empty($this->modeArray) ? ['VALUE_NONE'] : $this->modeArray;
 
@@ -75,10 +71,10 @@ class Option extends Input
      *
      * @return $this
      */
-    protected function setShortcut()
+    protected function setShortcut(): static
     {
         if (strpos($this->input, '|') !== false) {
-            list($this->shortcut, $this->input) = explode('|', $this->input);
+            [$this->shortcut, $this->input] = explode('|', $this->input);
         }
 
         return $this;
@@ -86,17 +82,15 @@ class Option extends Input
 
     /**
      * Get the option attributes.
-     *
-     * @return array
      */
-    public function getAttributes()
+    public function getAttributes(): array
     {
         return [
-            'name'        => $this->name,
-            'shortcut'    => $this->shortcut,
-            'mode'        => $this->mode,
+            'name' => $this->name,
+            'shortcut' => $this->shortcut,
+            'mode' => $this->mode,
             'description' => $this->description,
-            'default'     => $this->default,
+            'default' => $this->default,
         ];
     }
 }

--- a/src/Output/Logger.php
+++ b/src/Output/Logger.php
@@ -6,17 +6,13 @@ class Logger extends Output
 {
     /**
      * Log of received messages.
-     *
-     * @var array
      */
-    protected $log = [];
+    protected array $log = [];
 
     /**
      * Write a message.
-     *
-     * @param string $message
      */
-    public function write($message)
+    public function write(string $message): void
     {
         if ($this->verbosity) {
             $this->log[] = $message;
@@ -25,12 +21,8 @@ class Logger extends Output
 
     /**
      * Return the log array.
-     *
-     * @param int $index
-     *
-     * @return array
      */
-    public function getLog($index = null)
+    public function getLog(?int $index = null): array
     {
         if (is_null($index)) {
             return $this->log;
@@ -41,12 +33,8 @@ class Logger extends Output
 
     /**
      * Return true if log contains message.
-     *
-     * @param string $message
-     *
-     * @return bool
      */
-    public function hasMessage($message)
+    public function hasMessage(string $message): bool
     {
         return in_array($message, $this->getLog());
     }
@@ -54,7 +42,7 @@ class Logger extends Output
     /**
      * Clear the log.
      */
-    public function clearLog()
+    public function clearLog(): void
     {
         $this->log = [];
     }

--- a/src/Output/Output.php
+++ b/src/Output/Output.php
@@ -6,44 +6,34 @@ abstract class Output
 {
     /**
      * Output verbosity.
-     *
-     * @var bool
      */
-    protected $verbosity = true;
+    protected bool $verbosity = true;
 
     /**
      * Write a message.
-     *
-     * @param string $message
      */
-    abstract public function write($message);
+    abstract public function write(string $message): void;
 
     /**
      * Write an info message.
-     *
-     * @param string $message
      */
-    public function writeInfo($message)
+    public function writeInfo(string $message): void
     {
         $this->write("<info>{$message}</info>");
     }
 
     /**
      * Write an error message.
-     *
-     * @param string $message
      */
-    public function writeError($message)
+    public function writeError(string $message): void
     {
         $this->write("<error>{$message}</error>");
     }
 
     /**
      * Write a comment message.
-     *
-     * @param string $message
      */
-    public function writeComment($message)
+    public function writeComment(string $message): void
     {
         $this->write("<comment>{$message}</comment>");
     }
@@ -51,11 +41,10 @@ abstract class Output
     /**
      * Set the output verbosity.
      *
-     * @param bool $verbosity
      *
      * @return $this
      */
-    public function setVerbosity($verbosity)
+    public function setVerbosity(bool $verbosity): static
     {
         $this->verbosity = $verbosity;
 

--- a/src/Output/SymfonyOutput.php
+++ b/src/Output/SymfonyOutput.php
@@ -8,15 +8,11 @@ class SymfonyOutput extends Output
 {
     /**
      * Symfony command output.
-     *
-     * @var OutputInterface
      */
-    protected $output;
+    protected OutputInterface $output;
 
     /**
      * Construct.
-     *
-     * @param OutputInterface $output
      */
     public function __construct(OutputInterface $output)
     {
@@ -25,10 +21,8 @@ class SymfonyOutput extends Output
 
     /**
      * Write a message.
-     *
-     * @param string $message
      */
-    public function write($message)
+    public function write(string $message): void
     {
         if ($this->verbosity) {
             $this->output->writeln($message);
@@ -37,10 +31,8 @@ class SymfonyOutput extends Output
 
     /**
      * Get the Symfony output class.
-     *
-     * @return OutputInterface
      */
-    public function getOutput()
+    public function getOutput(): OutputInterface
     {
         return $this->output;
     }

--- a/src/SignatureParser.php
+++ b/src/SignatureParser.php
@@ -2,22 +2,18 @@
 
 namespace Artisanize;
 
-use Artisanize\Input\Option;
 use Artisanize\Input\Argument;
+use Artisanize\Input\Option;
 
 class SignatureParser
 {
     /**
      * The command to build.
-     *
-     * @var Command
      */
-    protected $command;
+    protected Command $command;
 
     /**
      * Construct.
-     *
-     * @param Command $command
      */
     public function __construct(Command $command)
     {
@@ -26,10 +22,8 @@ class SignatureParser
 
     /**
      * Parse the command signature.
-     *
-     * @param string $signature
      */
-    public function parse($signature)
+    public function parse(string $signature): void
     {
         $this->setName($signature);
 
@@ -48,22 +42,16 @@ class SignatureParser
 
     /**
      * Set the command name.
-     *
-     * @param string $signature
      */
-    protected function setName($signature)
+    protected function setName(string $signature): void
     {
         $this->command->setName(preg_split('/\s+/', $signature)[0]);
     }
 
     /**
      * Extract arguments and options from signature.
-     *
-     * @param string $signature
-     *
-     * @return array
      */
-    protected function extractArgumentsOptions($signature)
+    protected function extractArgumentsOptions(string $signature): array
     {
         preg_match_all('/{(.*?)}/', $signature, $argumentsOption);
 

--- a/tests/BaseTestCase.php
+++ b/tests/BaseTestCase.php
@@ -16,8 +16,7 @@ class BaseTestCase extends TestCase
     /**
      * Register a created file that should be unlinked during treardown.
      *
-     * @param string $path
-     *
+     * @param  string  $path
      * @return void
      */
     protected function registerCreatedFile($path)
@@ -37,7 +36,7 @@ class BaseTestCase extends TestCase
                 $dir = new \DirectoryIterator($path);
 
                 foreach ($dir as $file) {
-                    if (!$file->isDot()) {
+                    if (! $file->isDot()) {
                         unlink($file->getPathname());
                     }
                 }

--- a/tests/SignatureParserTest.php
+++ b/tests/SignatureParserTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests;
 
-use Tests\data\NullCommand;
 use Artisanize\SignatureParser;
+use Tests\data\NullCommand;
 
 class SignatureParserTest extends BaseTestCase
 {
@@ -23,14 +23,12 @@ class SignatureParserTest extends BaseTestCase
 
     /**
      * Setup the test class.
-     *
-     * @return void
      */
-    public function setUp(): void
+    protected function setUp(): void
     {
         parent::setUp();
 
-        $this->command = new NullCommand();
+        $this->command = new NullCommand;
 
         $this->parser = new SignatureParser($this->command);
     }

--- a/tests/data/NullCommand.php
+++ b/tests/data/NullCommand.php
@@ -6,65 +6,72 @@ use Artisanize\Command;
 
 class NullCommand extends Command
 {
-    protected $name;
+    protected ?string $name;
 
-    protected $description;
+    protected string $description = '';
 
-    protected $options = [];
+    protected array $options = [];
 
-    protected $arguments = [];
+    protected array $arguments = [];
 
-    public function __construct($name = null)
+    public function __construct(?string $name = null)
     {
         $this->name = $name;
     }
 
-    public function setName($name)
+    public function setName(string $name): static
     {
         $this->name = $name;
+
+        return $this;
     }
 
-    public function setDescription($description)
+    public function setDescription(string $description): static
     {
+        return $this;
     }
 
-    public function addArgument($name, $mode = null, $description = '', $default = null)
+    public function addArgument(string $name, ?int $mode = null, ?string $description = '', mixed $default = null, array|\Closure $suggestedValues = []): static
     {
         $this->arguments[] = [
-            'name'        => $name,
-            'mode'        => $mode,
+            'name' => $name,
+            'mode' => $mode,
             'description' => $description,
-            'default'     => $default,
+            'default' => $default,
         ];
+
+        return $this;
     }
 
-    public function addOption($name, $shortcut = null, $mode = null, $description = '', $default = null)
+    public function addOption(string $name, string|array|null $shortcut = null, ?int $mode = null, ?string $description = '', mixed $default = null, array|\Closure $suggestedValues = []): static
     {
         $this->options[] = [
-            'name'        => $name,
-            'shortcut'    => $shortcut,
-            'mode'        => $mode,
+            'name' => $name,
+            'shortcut' => $shortcut,
+            'mode' => $mode,
             'description' => $description,
-            'default'     => $default,
+            'default' => $default,
         ];
+
+        return $this;
     }
 
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
 
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
 
-    public function getArguments()
+    public function getArguments(): array
     {
         return $this->arguments;
     }
 
-    public function getOptions()
+    public function getOptions(): array
     {
         return $this->options;
     }


### PR DESCRIPTION
## Summary
- require PHP 8.2
- add phpstan and pint for development
- typehint source code and update command execution
- fix tests with updated NullCommand
- run pint for style fixes

## Testing
- `vendor/bin/phpstan analyse src --level 1 --no-progress --error-format table`
- `vendor/bin/phpunit -c phpunit.xml`


------
https://chatgpt.com/codex/tasks/task_e_687a6f45a6cc833099810c2138618f48